### PR TITLE
fix: Correct Firebase storageBucket URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@
           apiKey: "AIzaSyAYefDi9Njm_hsJavgup05WyxhPlVIGlAA",
           authDomain: "curly-happiness.firebaseapp.com",
           projectId: "curly-happiness",
-          storageBucket: "curly-happiness.firebasestorage.app",
+          storageBucket: "curly-happiness.appspot.com",
           messagingSenderId: "556696470832"
         };
 


### PR DESCRIPTION
The application was unable to connect to the database because the `storageBucket` URL in the `firebaseConfig` object was incorrect. This change corrects the URL to the proper format (`<projectId>.appspot.com`), which resolves the issue and allows tasks to be added to the Firestore database.

Note: The Firebase API key is currently hardcoded in `index.html`. For a production environment, it is strongly recommended to store this key more securely, for example, using environment variables or a backend proxy.